### PR TITLE
Allow email configuration by service parameters

### DIFF
--- a/approval-impl/pom.xml
+++ b/approval-impl/pom.xml
@@ -62,10 +62,6 @@
       <artifactId>commons-configuration</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax</groupId>
-      <artifactId>javaee-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
@@ -86,6 +82,11 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geronimo.javamail</groupId>
+      <artifactId>geronimo-javamail_1.4_mail</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>

--- a/approval-impl/src/main/java/org/oscm/app/dataaccess/AppDataService.java
+++ b/approval-impl/src/main/java/org/oscm/app/dataaccess/AppDataService.java
@@ -66,11 +66,15 @@ public class AppDataService {
     return s.getValue();
   }
 
-  public String loadBesWebServiceWsdl()  throws APPlatformException {
-    Setting s = getBasicSettings().getWsdlUrl();
+  public String loadBesWebServiceWsdl() throws APPlatformException {
+    String s = getBasicSettings().getWsdlUrl();
     if (s == null)
       throw new RuntimeException(
           String.format("Missing controller setting %s", "BSS_WEBSERVICE_WSDL_URL"));
-    return s.getValue();
+    return s;
+  }
+
+  public EmailSettings loadEmailSettings() throws APPlatformException {
+    return new EmailSettings(getBasicSettings().getParams());
   }
 }

--- a/approval-impl/src/main/java/org/oscm/app/dataaccess/EmailSettings.java
+++ b/approval-impl/src/main/java/org/oscm/app/dataaccess/EmailSettings.java
@@ -1,0 +1,56 @@
+/**
+ * *****************************************************************************
+ *
+ * <p>Copyright FUJITSU LIMITED 2020
+ *
+ * <p>Creation Date: 20.10.2020
+ *
+ * <p>*****************************************************************************
+ */
+package org.oscm.app.dataaccess;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** @author goebel */
+public class EmailSettings {
+
+  private static final Logger logger = LoggerFactory.getLogger(EmailSettings.class);
+  private Map<String, String> settings;
+
+  public EmailSettings(Map<String, String> settings) {
+    this.settings = settings;
+  }
+
+  public String getApprovalRecipients() {
+    final String r = settings.get("APPROVAL_RECIPIENTS");
+    logger.debug("APPROVAL_RECIPIENTS:" + r);
+    return r;
+  }
+
+  public String getApprovalMsgBody() {
+    final String b = settings.get("APPROVAL_MSG_BODY");
+    logger.debug("APPROVAL_MSG_BODY:" + b);
+    return b;
+  }
+
+  public String getApprovalSender() {
+    final String sn = settings.get("APPROVAL_MSG_SENDER");
+    logger.debug("APPROVAL_MSG_SENDER:" + sn);
+    return sn;
+  }
+
+  public String getApprovalSubject() {
+    final String sb = settings.get("APPROVAL_MSG_SUBJECT");
+    logger.debug("APPROVAL_MSG_SUBJECT", sb);
+    return sb;
+  }
+
+  public String getFormat() {
+    final String f = settings.get("FORMAT");
+    logger.debug("FORMAT", f);
+    return f;
+  }
+}

--- a/approval-impl/src/main/resources/ApprovalRequest.xml
+++ b/approval-impl/src/main/resources/ApprovalRequest.xml
@@ -1,84 +1,84 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright FUJITSU LIMITED 2020-->
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
+<!-- Copyright FUJITSU LIMITED 2020 -->
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xsi:schemaLocation="
        http://www.springframework.org/schema/beans 
        spring-beans-4.1.xsd
        http://www.springframework.org/schema/context
-       spring-context-4.1.xsd"
-       >        
- 
-	<context:property-placeholder location="classpath:beans.properties"/>
+       spring-context-4.1.xsd">
 
-    <bean id="Process" class="org.oscm.app.connector.framework.Process">
-        <property name="activity" ref="NotifyApprover"/>
-    </bean>
- 
-    <bean id="NotifyApprover" class="org.oscm.app.connector.activity.EmailWriter">
-        <property name="configuration">
-            <props>
-                <prop key="mailsession">${mail.session}</prop>
-            </props>
-        </property>
-        <property name="subject" value="$(mail.subject)"/>
-        <property name="body" value="&lt;html&gt;&lt;head&gt;&lt;meta http-equiv=&quot;Content-Type&quot; content=&quot;text/html; charset=UTF-8&quot;/&gt;   &lt;style&gt;     td, th, caption  { font: 15px arial;  }       caption  { font: bold 15px arial; background-color: #F2F2F2; margin:5px;}        .tcol       { width: 200px; }     .vcol       { width: 400px; }      .ckey        {  font: 15px arial; }      .cval        {  font: 15px arial; background-color: #F2F2F2; }   &lt;/style&gt;&lt;/head&gt; &lt;body&gt; &lt;p&gt; $(mail.body) &lt;/p&gt; &lt;hr/&gt;  &lt;table &gt;   &lt;caption&gt;SUBSCRIPTION TECHNICAL DATA&lt;/caption&gt;    &lt;colgroup&gt; &lt;col class=&quot;tcol&quot;/&gt;      &lt;col class=&quot;vcol&quot; /&gt;   &lt;/colgroup&gt;      &lt;tbody&gt;       &lt;tr &gt;      &lt;td class=&quot;ckey&quot;&gt;Service Name&lt;/td&gt;      &lt;td class=&quot;cval&quot;&gt;$(service.name)&lt;/td&gt;    &lt;/tr&gt;    &lt;tr &gt;      &lt;td class=&quot;ckey&quot;&gt;Technical Service ID&lt;/td&gt;      &lt;td class=&quot;cval&quot;&gt;$(service.technicalId)&lt;/td&gt;    &lt;/tr&gt;    &lt;tr &gt;      &lt;td class=&quot;ckey&quot;&gt;Organisation ID&lt;/td&gt;      &lt;td class=&quot;cval&quot;&gt;$(user.orgId)&lt;/td&gt;    &lt;/tr&gt;    &lt;tr &gt;      &lt;td class=&quot;ckey&quot;&gt;User Key&lt;/td&gt;      &lt;td class=&quot;cval&quot;&gt;$(user.key)&lt;/td&gt;    &lt;/tr&gt;       &lt;/tbody&gt;  &lt;/table &gt;     &lt;hr/&gt;      &lt;table &gt;    &lt;caption&gt;USER DATA&lt;/caption&gt;    &lt;colgroup &gt;       &lt;col class=&quot;tcol&quot;/&gt;    &lt;col class=&quot;vcol&quot;/&gt;     &lt;/colgroup&gt;      &lt;tbody&gt;      &lt;tr &gt;        &lt;td class=&quot;ckey&quot;&gt;First Name&lt;/td&gt;   &lt;td class=&quot;cval&quot;&gt;$(user.firstname)&lt;/td&gt;      &lt;/tr&gt;      &lt;tr &gt;        &lt;td class=&quot;ckey&quot;&gt;Name&lt;/td&gt;        &lt;td class=&quot;cval&quot;&gt;$(user.lastname)&lt;/td&gt;      &lt;/tr &gt;      &lt;tr &gt;        &lt;td class=&quot;ckey&quot;&gt;Email&lt;/td&gt;        &lt;td class=&quot;cval&quot;&gt;$(user.email)&lt;/td&gt;      &lt;/tr &gt;    &lt;/tbody&gt;   &lt;/table &gt;      &lt;hr/&gt;   &lt;br/&gt;&lt;br/&gt;&lt;p&gt;Best regards,&lt;/p&gt;&lt;p&gt;OSCM Approval Master&lt;br/&gt;&lt;/p&gt;  &lt;/body&gt; &lt;/html&gt;"/>
-				<property name="recipients" value="security@edeka.de"/>
-        <property name="sender" value="oscm@edeka.de"/>
-        <property name="format" value="text/html; charset=utf-8"/>
-        <property name="nextActivity" ref="GetApproverTKey"/>
-    </bean>
+  <context:property-placeholder location="classpath:beans.properties" />
 
-   <bean id="GetApproverTKey" class="org.oscm.app.connector.activity.DatabaseReader">
-        <property name="configuration">
-            <props>
-                <prop key="url">${database.url}</prop>
-                <prop key="driver">${database.driver}</prop>
-                <prop key="username">${database.username}</prop>
-                <prop key="password">${database.password}</prop>
-            </props>
-        </property>
-        <property name="statement" value="select tkey from approver where userid = 'approver'"/>
-        <property name="namespace" value="approver"/>
-       <property name="nextActivity" ref="Gateway"/>
-    </bean>
+  <bean id="Process" class="org.oscm.app.connector.framework.Process">
+    <property name="activity" ref="NotifyApprover" />
+  </bean>
 
-   <bean id="Gateway" class="org.oscm.app.connector.activity.Gateway">
-   
-         <property name="activity1" ref="CreateApprovalTask"/>
-         <property name="condition1" value="Integer.parseInt(approver.tkey) >= 0"/>
+  <bean id="NotifyApprover" class="org.oscm.app.approval.activity.EmailWriter">
+    <property name="configuration">
+      <props>
+        <prop key="mailsession">${mail.session}</prop>
+      </props>
+    </property>
+    <property name="subject" value="$(mail.subject)" />
+    <property name="body"
+      value="&lt;html&gt;&lt;head&gt;&lt;meta http-equiv=&quot;Content-Type&quot; content=&quot;text/html; charset=UTF-8&quot;/&gt;   &lt;style&gt;     td, th, caption  { font: 15px arial;  }       caption  { font: bold 15px arial; background-color: #F2F2F2; margin:5px;}        .tcol       { width: 200px; }     .vcol       { width: 400px; }      .ckey        {  font: 15px arial; }      .cval        {  font: 15px arial; background-color: #F2F2F2; }   &lt;/style&gt;&lt;/head&gt; &lt;body&gt; &lt;p&gt; $(mail.body) &lt;/p&gt; &lt;hr/&gt;  &lt;table &gt;   &lt;caption&gt;SUBSCRIPTION TECHNICAL DATA&lt;/caption&gt;    &lt;colgroup&gt; &lt;col class=&quot;tcol&quot;/&gt;      &lt;col class=&quot;vcol&quot; /&gt;   &lt;/colgroup&gt;      &lt;tbody&gt;       &lt;tr &gt;      &lt;td class=&quot;ckey&quot;&gt;Service Name&lt;/td&gt;      &lt;td class=&quot;cval&quot;&gt;$(service.name)&lt;/td&gt;    &lt;/tr&gt;    &lt;tr &gt;      &lt;td class=&quot;ckey&quot;&gt;Technical Service ID&lt;/td&gt;      &lt;td class=&quot;cval&quot;&gt;$(service.technicalId)&lt;/td&gt;    &lt;/tr&gt;    &lt;tr &gt;      &lt;td class=&quot;ckey&quot;&gt;Organisation ID&lt;/td&gt;      &lt;td class=&quot;cval&quot;&gt;$(user.orgId)&lt;/td&gt;    &lt;/tr&gt;    &lt;tr &gt;      &lt;td class=&quot;ckey&quot;&gt;User Key&lt;/td&gt;      &lt;td class=&quot;cval&quot;&gt;$(user.key)&lt;/td&gt;    &lt;/tr&gt;       &lt;/tbody&gt;  &lt;/table &gt;     &lt;hr/&gt;      &lt;table &gt;    &lt;caption&gt;USER DATA&lt;/caption&gt;    &lt;colgroup &gt;       &lt;col class=&quot;tcol&quot;/&gt;    &lt;col class=&quot;vcol&quot;/&gt;     &lt;/colgroup&gt;      &lt;tbody&gt;      &lt;tr &gt;        &lt;td class=&quot;ckey&quot;&gt;First Name&lt;/td&gt;   &lt;td class=&quot;cval&quot;&gt;$(user.firstname)&lt;/td&gt;      &lt;/tr&gt;      &lt;tr &gt;        &lt;td class=&quot;ckey&quot;&gt;Name&lt;/td&gt;        &lt;td class=&quot;cval&quot;&gt;$(user.lastname)&lt;/td&gt;      &lt;/tr &gt;      &lt;tr &gt;        &lt;td class=&quot;ckey&quot;&gt;Email&lt;/td&gt;        &lt;td class=&quot;cval&quot;&gt;$(user.email)&lt;/td&gt;      &lt;/tr &gt;    &lt;/tbody&gt;   &lt;/table &gt;      &lt;hr/&gt;   &lt;br/&gt;&lt;br/&gt;&lt;p&gt;Best regards,&lt;/p&gt;&lt;p&gt;OSCM Approval Master&lt;br/&gt;&lt;/p&gt;  &lt;/body&gt; &lt;/html&gt;" />
+    <property name="recipients" value="security@edeka.de" />
+    <property name="sender" value="oscm@edeka.de" />
+    <property name="format" value="text/html; charset=utf-8" />
+    <property name="nextActivity" ref="GetApproverTKey" />
+  </bean>
 
-         <property name="activity2" ref="CreateApprover"/>
-         <property name="condition2" value="true"/>
+  <bean id="GetApproverTKey" class="org.oscm.app.connector.activity.DatabaseReader">
+    <property name="configuration">
+      <props>
+        <prop key="url">${database.url}</prop>
+        <prop key="driver">${database.driver}</prop>
+        <prop key="username">${database.username}</prop>
+        <prop key="password">${database.password}</prop>
+      </props>
+    </property>
+    <property name="statement" value="select tkey from approver where userid = 'approver'" />
+    <property name="namespace" value="approver" />
+    <property name="nextActivity" ref="Gateway" />
+  </bean>
 
-     </bean>
+  <bean id="Gateway" class="org.oscm.app.connector.activity.Gateway">
+
+    <property name="activity1" ref="CreateApprovalTask" />
+    <property name="condition1" value="Integer.parseInt(approver.tkey) >= 0" />
+
+    <property name="activity2" ref="CreateApprover" />
+    <property name="condition2" value="true" />
+
+  </bean>
 
 
-   <bean id="CreateApprover" class="org.oscm.app.connector.activity.DatabaseWriter">
-        <property name="configuration">
-            <props>
-                <prop key="url">${database.url}</prop>
-                <prop key="driver">${database.driver}</prop>
-                <prop key="username">${database.username}</prop>
-                <prop key="password">${database.password}</prop>
-            </props>
-        </property>
-        <property name="statement" value="insert into approver (tkey,userid) values (DEFAULT,'approver') returning tkey"/>
-        <property name="namespace" value="approver"/>
-       <property name="nextActivity" ref="CreateApprovalTask"/>
-    </bean>
-	
-    <bean id="CreateApprovalTask" class="org.oscm.app.connector.activity.DatabaseWriter">
-        <property name="configuration">
-            <props>
-                <prop key="url">${database.url}</prop>
-                <prop key="driver">${database.driver}</prop>
-                <prop key="username">${database.username}</prop>
-                <prop key="password">${database.password}</prop>
-            </props>
-        </property>
-        <property name="statement" value="insert into task (tkey,triggerkey,triggername,orgid,orgname,requestinguser,description,comment,created,status_tkey,approver_tkey) values (DEFAULT,$(ctmg_trigger_key),'$(ctmg_trigger_name)','$(organization.id)','$(organization.name)','$(user.userid)','$(task.description)','',current_timestamp,1,$(approver.tkey))"/>
-   </bean>
-	
+  <bean id="CreateApprover" class="org.oscm.app.connector.activity.DatabaseWriter">
+    <property name="configuration">
+      <props>
+        <prop key="url">${database.url}</prop>
+        <prop key="driver">${database.driver}</prop>
+        <prop key="username">${database.username}</prop>
+        <prop key="password">${database.password}</prop>
+      </props>
+    </property>
+    <property name="statement" value="insert into approver (tkey,userid) values (DEFAULT,'approver') returning tkey" />
+    <property name="namespace" value="approver" />
+    <property name="nextActivity" ref="CreateApprovalTask" />
+  </bean>
+
+  <bean id="CreateApprovalTask" class="org.oscm.app.connector.activity.DatabaseWriter">
+    <property name="configuration">
+      <props>
+        <prop key="url">${database.url}</prop>
+        <prop key="driver">${database.driver}</prop>
+        <prop key="username">${database.username}</prop>
+        <prop key="password">${database.password}</prop>
+      </props>
+    </property>
+    <property name="statement"
+      value="insert into task (tkey,triggerkey,triggername,orgid,orgname,requestinguser,description,comment,created,status_tkey,approver_tkey) values (DEFAULT,$(ctmg_trigger_key),'$(ctmg_trigger_name)','$(organization.id)','$(organization.name)','$(user.userid)','$(task.description)','',current_timestamp,1,$(approver.tkey))" />
+  </bean>
+
 </beans>

--- a/approval-impl/src/test/java/org/oscm/app/approval/activity/EmailWriterTest.java
+++ b/approval-impl/src/test/java/org/oscm/app/approval/activity/EmailWriterTest.java
@@ -1,0 +1,220 @@
+/**
+ * ******************************************************************************
+ *
+ * <p>Copyright FUJITSU LIMITED 2020
+ *
+ * <p>*****************************************************************************
+ */
+package org.oscm.app.approval.activity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.MimeMessage;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.oscm.app.connector.framework.Activity;
+import org.oscm.app.connector.framework.ProcessException;
+import org.oscm.app.connector.util.SpringBeanSupport;
+import org.oscm.app.dataaccess.AppDataService;
+import org.oscm.app.dataaccess.EmailSettings;
+import org.postgresql.core.ConnectionFactory;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.management.*", "javax.script.*"})
+@PrepareForTest({
+  EmailWriter.class,
+  Properties.class,
+  Session.class,
+  Context.class,
+  Transport.class,
+  LoggerFactory.class,
+  AppDataService.class
+})
+@SuppressWarnings("boxing")
+public class EmailWriterTest {
+
+  private EmailWriter emailWriter;
+  private Properties props;
+  private Activity activity;
+  private Session session;
+  private Logger logger;
+  private static InitialContext initialContext;
+  private AppDataService dataService;
+  private Map<String, String> transmitData;
+  private Map<String, String> emailSettings;
+
+  @BeforeClass
+  public static void oneTimeSetup() {
+    System.setProperty("log4j.defaultInitOverride", Boolean.toString(true));
+    System.setProperty("log4j.ignoreTCL", Boolean.toString(true));
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    transmitData = new HashMap<>();
+    emailSettings = new HashMap<String, String>();
+    emailWriter = PowerMockito.spy(new EmailWriter());
+    props = mock(Properties.class);
+    activity = mock(Activity.class);
+    session = mock(Session.class);
+    logger = mock(Logger.class);
+    initialContext = mock(InitialContext.class);
+    dataService = mock(AppDataService.class);
+
+    Whitebox.setInternalState(EmailWriter.class, "logger", logger);
+    PowerMockito.whenNew(AppDataService.class).withNoArguments().thenReturn(dataService);
+
+    PowerMockito.when(dataService.loadEmailSettings()).thenReturn(new EmailSettings(emailSettings));
+  }
+
+  @Test
+  public void testDoConfigure() throws Exception {
+
+    String url = "url";
+    when(props.containsKey(any())).thenReturn(true);
+    when(props.getProperty(anyString())).thenReturn(url);
+    when(SpringBeanSupport.getProperty(props, anyString(), null)).thenReturn(url);
+
+    emailWriter.doConfigure(props);
+
+    String mailSession = Whitebox.getInternalState(emailWriter, "mailSession");
+    assertEquals(url, mailSession);
+    verify(logger, times(1)).debug(contains("beanName: "));
+  }
+
+  @Test(expected = ProcessException.class)
+  public void testDoConfigureThrowException() throws Exception {
+
+    when(props.containsKey(any())).thenReturn(true);
+    when(props.getProperty(anyString())).thenReturn(null);
+    when(SpringBeanSupport.getProperty(props, anyString(), null)).thenReturn(null);
+
+    emailWriter.doConfigure(props);
+  }
+
+  @Test
+  public void testTransmitReceiveDataOnce() throws Exception {
+    transmitData.put("subject", "subjectValue");
+    PowerMockito.doNothing()
+        .when(emailWriter, PowerMockito.method(EmailWriter.class, "sendEmail"))
+        .withArguments(eq(transmitData));
+
+    final Map<String, String> result = emailWriter.transmitReceiveData(transmitData);
+
+    PowerMockito.verifyPrivate(emailWriter, times(1)).invoke("getNextActivity");
+    PowerMockito.verifyPrivate(emailWriter, times(1)).invoke("sendEmail", transmitData);
+    verify(logger, times(1)).debug(contains("beanName: "));
+    assertEquals(transmitData, result);
+  }
+
+  @Test
+  public void testTransmitReceiveDataTwice() throws Exception {
+    transmitData.put("subject", "subjectValue");
+    emailWriter.setNextActivity(activity);
+
+    PowerMockito.doNothing()
+        .when(emailWriter, PowerMockito.method(EmailWriter.class, "sendEmail"))
+        .withArguments(eq(transmitData));
+
+    final Map<String, String> result = emailWriter.transmitReceiveData(transmitData);
+
+    PowerMockito.verifyPrivate(emailWriter, times(2)).invoke("getNextActivity");
+    assertNotEquals(transmitData, result);
+  }
+
+  @Test
+  public void testSendEmail() throws Exception {
+    transmitData.put("subject", "subjectValue");
+    transmitData.put("body", "://body.com");
+    transmitData.put("sender", "senderValue");
+    emailWriter.setSubject("_$(subject)");
+    emailWriter.setBody("html$(body)");
+    emailWriter.setSender("_$(sender)");
+    emailWriter.setRecipients("Recipients");
+
+    PowerMockito.doReturn(true).when(emailWriter, "isHtmlContent", anyString());
+    PowerMockito.doReturn(session).when(emailWriter, "getMailSession");
+    PowerMockito.mockStatic(Transport.class);
+    PowerMockito.doNothing().when(Transport.class, "send", Mockito.any(MimeMessage.class));
+
+    Whitebox.invokeMethod(emailWriter, "sendEmail", transmitData);
+
+    PowerMockito.verifyPrivate(emailWriter, times(1)).invoke("getMailSession");
+    PowerMockito.verifyStatic(Transport.class, Mockito.times(1));
+    Transport.send(Mockito.any());
+    verify(logger, times(2)).debug(anyString());
+  }
+
+  @Test(expected = Exception.class)
+  public void testSendEmailException() throws Exception {
+    transmitData.put("subject", "subjectValue");
+    transmitData.put("body", "://body.com");
+    transmitData.put("sender", "senderValue");
+    emailWriter.setSubject("_$(subject)");
+    emailWriter.setBody("html$(body)");
+    emailWriter.setSender("_$(sender)");
+
+    PowerMockito.doReturn(null).when(emailWriter, "getMailSession");
+
+    Whitebox.invokeMethod(emailWriter, "sendEmail", transmitData);
+  }
+
+  @Test
+  public void testGetMailSession() throws Exception {
+
+    System.setProperty(
+        "java.naming.factory.initial", getClass().getCanonicalName() + "$MyContextFactory");
+
+    Whitebox.invokeMethod(emailWriter, "getMailSession");
+
+    verify(initialContext, times(1)).lookup(anyString());
+  }
+
+  @Test(expected = Exception.class)
+  public void testGetMailSessionException() throws Exception {
+
+    System.setProperty("java.naming.factory.initial", getClass().getCanonicalName());
+
+    Whitebox.invokeMethod(emailWriter, "getMailSession");
+  }
+
+  public static class MyContextFactory implements InitialContextFactory {
+    @Override
+    public Context getInitialContext(Hashtable<?, ?> environment) throws NamingException {
+      ConnectionFactory mockConnFact = mock(ConnectionFactory.class);
+      when(initialContext.lookup("jms1")).thenReturn(mockConnFact);
+      return initialContext;
+    }
+  }
+}

--- a/approval-impl/src/test/java/org/oscm/app/dataaccess/AppDataServiceTest.java
+++ b/approval-impl/src/test/java/org/oscm/app/dataaccess/AppDataServiceTest.java
@@ -135,7 +135,7 @@ public class AppDataServiceTest {
   public void getApprovalUrl() throws Exception {
     // given
     authentication = new PasswordAuthentication("admin", "adminpwd");
-    defineCustomAttribute("APPROVAL_URL", "http://oscm-app/approval");
+    defineConfigSetting("APPROVAL_URL", "http://oscm-app/approval");
     defineCustomAttribute("BSS_WEBSERVICE_WSDL_URL", "http://oscm-core/trigger?wsld");
     defineCustomAttribute("APPROVER_ORG_ID_1af3c", "approver");
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
       <dependency>
         <groupId>com.github.servicecatalog.oscm-app</groupId>
         <artifactId>oscm-app-approval</artifactId>
-        <version>master-SNAPSHOT</version>
+        <version>task~approval-settings-97-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
**Changes in this Pull Request:**
- Allow overriding default configuration from XML file fead spring beans with service parameters, which are provided by the supplier with the approval tool instance
- Moved email writer activity in approval-impl module for data access
- Fix class version clash between geronimo-javamail and javeee (e.g. javax.mail.internet.MimeMessage provided with both jars)

**Mandatory checks:**
- [X] Branch is up to date (latest changes were fetched from the upstream branch before creating this PR)
- [ ] Changes were tested manually
- [ ] Java code changes are unit tested

**To be checked by the reviewer:**
- [ ] Clean Java code and unit tested changes 

**To be checked by the pull request owner:**
- [ ] .MASTER/job/BES_MASTER_IT/
- [ ] .MASTER/job/OSCM_WS_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_WS_Tests_OIDC/
- [ ] .MASTER/job/OSCM_Integration_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_Integration_Tests_OIDC/

**Cross repository and core changes:**
- [ ] Interdependent changes have been communicated to the team (if applicable)
- [ ] This pull request includes high risk modifications or core changes (e.g API, datamodel, authentication...). Mandatory reviewers: @goebell or @kowalczyka.

**OSCM Build References:**
- TODO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-approval/47)
<!-- Reviewable:end -->
